### PR TITLE
Improvements on internal logic.

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -32,6 +32,7 @@ def timeInAir(y0, y, Vy):
 
         while t < 100000:
 
+            y0p = y0
             y0 += Vy
             Vy = 0.99 * Vy - 0.05
 
@@ -39,6 +40,10 @@ def timeInAir(y0, y, Vy):
 
             if y0 > y:  # Will break when the projectile gets higher than target
                 break
+
+            # If the projectile stopped ascending before going above target then it will never hit it, so return early
+            if y0 - y0p < 0:
+                return "Error"
 
     while t < 100000:
 

--- a/calculator.py
+++ b/calculator.py
@@ -8,14 +8,6 @@ def myLinspace(start, end, num):
     answer.append(end)
     return answer
 
-# filters numbers from linspace between max and min
-def flinspace(start, stop, num_elements, min, max):
-    items = []
-    for item in myLinspace(start, stop, num_elements):
-        if item < min or item > max: continue
-        items.append(item)
-    return items
-
 class OutOfRangeException(Exception):
     pass
 
@@ -151,7 +143,7 @@ def BallisticsToTarget(cannon, target, power, direction, lenght, check_impossibl
 
 
         deltaTimes = []
-        for triedPitch in flinspace(low, high, nbOfElements, -30, 60):
+        for triedPitch in myLinspace(max(low, -30), min(high, 60), nbOfElements):
             # Bias that the cannon is probably gonna aim up instead of down
             # No use for now, useful for a later optimisation
 

--- a/calculator.py
+++ b/calculator.py
@@ -1,4 +1,9 @@
+
 from math import sin, cos, atan, sqrt, pi, radians, log
+
+class OutOfRangeException(Exception):
+    pass
+
 
 def myLinspace(start, end, num):
     answer = [start]
@@ -7,9 +12,6 @@ def myLinspace(start, end, num):
         answer.append(answer[-1] + delta)
     answer.append(end)
     return answer
-
-class OutOfRangeException(Exception):
-    pass
 
 def timeInAir(y0, y, Vy):
     """Find the air time of the projectile, using recursive sequence.
@@ -97,7 +99,7 @@ def BallisticsToTarget(cannon, target, power, direction, lenght, check_impossibl
     distance = sqrt(Dx * Dx + Dz * Dz)
     # Horizontal distance between target and mount
 
-    initialSpeed = power
+    initialSpeed = power * 2
 
     nbOfIterations = 5  # by default
 


### PR DESCRIPTION
These improvements are something that I've used in my version of ballistic calculator.
**1st commit:** 
When the target is above cannon and it doesn't have enough energy to go above target, it will simulate all the way to t_max, which can be easily prevented and causes significant slowdown.
**2nd commit**
Some targets projectile will hit on ascension. As it is now, program will completely ignore it, causing delta_t to become falsely large in those cases. This commit fixes it
**3rd and 4th commits**
While I did use the same logic at first, I found a "better" way to determine if it's possible to hit target. Instead of determining it pitch is bigger or smaller than boundary, delta_t will naturally show it, so instead just check if delta_t is bigger than max_delta_t_error. I'm also using a linspace with boundaries, to limit angles.
Also, high and low shots can be the same values, or a high shot can be impossible while a low shot is, so I added some checks to prevent useless calculations.